### PR TITLE
Change ceedling to https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tools/ceedling"]
 	path = tools/ceedling
-	url = git@github.com:ThrowTheSwitch/Ceedling.git
+	url = https://github.com/ThrowTheSwitch/Ceedling.git


### PR DESCRIPTION
Some people did not add ssh key to their account. Since ceedling submodules also use https we can afford to switch to https instead of ssh.

Closes #9 