### PR TITLE
Adding ID_CONSUMER to valid EEPROM identifier

### DIFF
--- a/inc/mlx90632.h
+++ b/inc/mlx90632.h
@@ -134,8 +134,8 @@
 #define MLX90632_TIMING_EEPROM 100 /**< Time between EEPROM writes */
 
 /* Magic constants */
-#define MLX90632_ID_MEDICAL	0x0105 /* EEPROM DSPv5 Medical device id */
-#define MLX90632_ID_CONSUMER	0x0205 /* EEPROM DSPv5 Consumer device id */
+#define MLX90632_ID_MEDICAL 0x0105 /* EEPROM DSPv5 Medical device id */
+#define MLX90632_ID_CONSUMER    0x0205 /* EEPROM DSPv5 Consumer device id */
 #define MLX90632_EEPROM_VERSION MLX90632_ID_MEDICAL /**< Legacy define - to be deprecated */
 #define MLX90632_EEPROM_WRITE_KEY 0x554C /**< EEPROM write key 0x55 and 0x4c */
 #define MLX90632_RESET_CMD  0x0006 /**< Reset sensor (address or global) */

--- a/inc/mlx90632.h
+++ b/inc/mlx90632.h
@@ -134,7 +134,9 @@
 #define MLX90632_TIMING_EEPROM 100 /**< Time between EEPROM writes */
 
 /* Magic constants */
-#define MLX90632_EEPROM_VERSION 0x105 /**< EEPROM DSP version for constants */
+#define MLX90632_ID_MEDICAL	0x0105 /* EEPROM DSPv5 Medical device id */
+#define MLX90632_ID_CONSUMER	0x0205 /* EEPROM DSPv5 Consumer device id */
+#define MLX90632_EEPROM_VERSION MLX90632_ID_MEDICAL /**< Legacy define - to be deprecated */
 #define MLX90632_EEPROM_WRITE_KEY 0x554C /**< EEPROM write key 0x55 and 0x4c */
 #define MLX90632_RESET_CMD  0x0006 /**< Reset sensor (address or global) */
 #define MLX90632_MAX_MEAS_NUM   31 /**< Maximum number of measurements in list */

--- a/src/mlx90632.c
+++ b/src/mlx90632.c
@@ -359,7 +359,7 @@ int32_t mlx90632_init(void)
         return ret;
     }
 
-    if ((eeprom_version != MLX90632_ID_MEDICAL) || (eeprom_version != MLX90632_ID_CONSUMER))
+    if ((eeprom_version != MLX90632_ID_MEDICAL) && (eeprom_version != MLX90632_ID_CONSUMER))
     {
         // this here can fail because of big/little endian of cpu/i2c
         return -EPROTONOSUPPORT;

--- a/src/mlx90632.c
+++ b/src/mlx90632.c
@@ -359,7 +359,7 @@ int32_t mlx90632_init(void)
         return ret;
     }
 
-    if (eeprom_version != MLX90632_EEPROM_VERSION)
+    if ((eeprom_version != MLX90632_ID_MEDICAL) || (eeprom_version != MLX90632_ID_CONSUMER))
     {
         // this here can fail because of big/little endian of cpu/i2c
         return -EPROTONOSUPPORT;

--- a/test/TestInit.c
+++ b/test/TestInit.c
@@ -59,6 +59,24 @@ void test_init_success(void)
     mlx90632_i2c_write_ExpectAndReturn(MLX90632_REG_STATUS, reg_status_mock & ~0x01, 0);
 
     TEST_ASSERT_EQUAL_INT(0, mlx90632_init());
+
+    // test also ID_CONSUMER
+    eeprom_version_mock = 0x205;
+
+    // Confirm EEPROM version
+    mlx90632_i2c_read_ExpectAndReturn(MLX90632_EE_VERSION, &eeprom_version_mock, 0);
+    mlx90632_i2c_read_IgnoreArg_value(); // Ignore input of mock since we use it as output
+    mlx90632_i2c_read_ReturnThruPtr_value(&eeprom_version_mock);
+
+    // Read REG_STATUS
+    mlx90632_i2c_read_ExpectAndReturn(MLX90632_REG_STATUS, &reg_status_mock, 0);
+    mlx90632_i2c_read_IgnoreArg_value(); // Ignore input of mock since we use it as output
+    mlx90632_i2c_read_ReturnThruPtr_value(&reg_status_mock);
+
+    // Reset EOC and NewData
+    mlx90632_i2c_write_ExpectAndReturn(MLX90632_REG_STATUS, reg_status_mock & ~0x01, 0);
+
+    TEST_ASSERT_EQUAL_INT(0, mlx90632_init());
 }
 
 void test_init_wrong_eeprom_version(void)


### PR DESCRIPTION
There is now a Consumer version of the mlx90632 available which has wider temperature range and different accuracy.