### PR TITLE
Remove calibration ID and use only DSP version check

### DIFF
--- a/inc/mlx90632.h
+++ b/inc/mlx90632.h
@@ -134,8 +134,7 @@
 #define MLX90632_TIMING_EEPROM 100 /**< Time between EEPROM writes */
 
 /* Magic constants */
-#define MLX90632_ID_MEDICAL 0x0105 /* EEPROM DSPv5 Medical device id */
-#define MLX90632_ID_CONSUMER    0x0205 /* EEPROM DSPv5 Consumer device id */
+#define MLX90632_DSPv5 0x05 /* EEPROM DSP version */
 #define MLX90632_EEPROM_VERSION MLX90632_ID_MEDICAL /**< Legacy define - to be deprecated */
 #define MLX90632_EEPROM_WRITE_KEY 0x554C /**< EEPROM write key 0x55 and 0x4c */
 #define MLX90632_RESET_CMD  0x0006 /**< Reset sensor (address or global) */

--- a/src/mlx90632.c
+++ b/src/mlx90632.c
@@ -359,7 +359,7 @@ int32_t mlx90632_init(void)
         return ret;
     }
 
-    if ((eeprom_version != MLX90632_ID_MEDICAL) && (eeprom_version != MLX90632_ID_CONSUMER))
+    if ((eeprom_version & 0x00FF) != MLX90632_DSPv5)
     {
         // this here can fail because of big/little endian of cpu/i2c
         return -EPROTONOSUPPORT;

--- a/test/TestInit.c
+++ b/test/TestInit.c
@@ -38,8 +38,7 @@ void SetUp(void)
 {
 }
 
-/** Test initialization process
- */
+/** Test initialization process */
 void test_init_success(void)
 {
     uint16_t eeprom_version_mock = 0x105;
@@ -62,6 +61,24 @@ void test_init_success(void)
 
     // test also ID_CONSUMER
     eeprom_version_mock = 0x205;
+
+    // Confirm EEPROM version
+    mlx90632_i2c_read_ExpectAndReturn(MLX90632_EE_VERSION, &eeprom_version_mock, 0);
+    mlx90632_i2c_read_IgnoreArg_value(); // Ignore input of mock since we use it as output
+    mlx90632_i2c_read_ReturnThruPtr_value(&eeprom_version_mock);
+
+    // Read REG_STATUS
+    mlx90632_i2c_read_ExpectAndReturn(MLX90632_REG_STATUS, &reg_status_mock, 0);
+    mlx90632_i2c_read_IgnoreArg_value(); // Ignore input of mock since we use it as output
+    mlx90632_i2c_read_ReturnThruPtr_value(&reg_status_mock);
+
+    // Reset EOC and NewData
+    mlx90632_i2c_write_ExpectAndReturn(MLX90632_REG_STATUS, reg_status_mock & ~0x01, 0);
+
+    TEST_ASSERT_EQUAL_INT(0, mlx90632_init());
+
+    // test also better accuracy
+    eeprom_version_mock = 0x305;
 
     // Confirm EEPROM version
     mlx90632_i2c_read_ExpectAndReturn(MLX90632_EE_VERSION, &eeprom_version_mock, 0);

--- a/test/TestInit.c
+++ b/test/TestInit.c
@@ -77,7 +77,7 @@ void test_init_success(void)
 
     TEST_ASSERT_EQUAL_INT(0, mlx90632_init());
 
-    // test also better accuracy
+    // test also another calibration id
     eeprom_version_mock = 0x305;
 
     // Confirm EEPROM version


### PR DESCRIPTION
We still want to check for endianess, but without the dependency on the calibration ID.

This is a quick fix method since chips with calibration ID 3 are already in field.