### PR TITLE
Add Werror to the build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,6 +163,8 @@ jobs:
             - gcc-multilib
       env:
          - COPYBINS="sudo ln -fs /usr/bin/gcc-7 /usr/bin/gcc"
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
     - stage: test
       before_script: pip install --user gcovr==3.3
       script: make CC=clang utest

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ OBJDIR := build
 TARGET = mlx90632
 
 # Flags
-CFLAGS += -Wall		# just something for warnings...
+CFLAGS += -Wall -Wpedantic     # just something for warnings...
+CFLAGS += -Werror              # Make sure we dont have any warnings
 ARFLAGS = rcs
 # optimization levels
 # -------------------

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverity Scan](https://img.shields.io/coverity/scan/14522.svg)](https://scan.coverity.com/projects/melexis-mlx90632-library)
 [![Documentation](https://img.shields.io/badge/Documentation-published-brightgreen.svg)](https://melexis.github.io/mlx90632-library/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4367/badge)](https://bestpractices.coreinfrastructure.org/projects/4367)
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/melexis/mlx90632-library/issues)
 
 This is 90632 example driver with virtual i2c read/write functions. There will


### PR DESCRIPTION
We want to get FOSS badge, so we need to have enforceable 0 warning policy