### PR TITLE
Fixing doxygen deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,10 +1,5 @@
 name: Doxygen
-on:
-  push:
-    branches: [ master ]
-    tags: [ '*' ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 jobs:
   doc:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,7 @@ name: Doxygen
 on:
   push:
     branches: [ master ]
+    tags: [ '*' ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
It was not working because it only ran on push to master branch but not
on tag. This fix should enable it to run also on tags.