### PR TITLE
Use strict prototypes for the functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ TARGET = mlx90632
 # Flags
 CFLAGS += -Wall -Wpedantic     # just something for warnings...
 CFLAGS += -Werror              # Make sure we dont have any warnings
+CFLAGS += -Wstrict-prototypes  # Make sure we have strict prototyping for functions
 ARFLAGS = rcs
 # optimization levels
 # -------------------

--- a/src/mlx90632.c
+++ b/src/mlx90632.c
@@ -675,12 +675,12 @@ int32_t mlx90632_trigger_measurement_single(void)
     return ret;
 }
 
-STATIC int32_t mlx90632_unlock_eeporm()
+STATIC int32_t mlx90632_unlock_eeporm(void)
 {
     return mlx90632_i2c_write(0x3005, MLX90632_EEPROM_WRITE_KEY);
 }
 
-STATIC int32_t mlx90632_wait_for_eeprom_not_busy()
+STATIC int32_t mlx90632_wait_for_eeprom_not_busy(void)
 {
     uint16_t reg_status;
     int32_t ret = mlx90632_i2c_read(MLX90632_REG_STATUS, &reg_status);


### PR DESCRIPTION
This will help us have a bit more cleaner code when additional warnings are presented.

It's a small effort so that people can enable a bit more warning flags.