### PR TITLE
Remove BITS_PER_LONG reference

### DIFF
--- a/.github/workflows/c-cpp-coveralls.yml
+++ b/.github/workflows/c-cpp-coveralls.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y gcc-${{ matrix.gcc_version }} ruby rake gcc-multilib lcov wget
         pip install gcovr==5.0
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/0.32.0-772f5f4/ceedling-0.32.0-772f5f4.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/1.0.0-60c24c2/ceedling-1.0.0-60c24c2.gem -O ceedling.gem
         sudo gem install ceedling.gem
         sudo gem install coveralls-lcov
         sudo ln -fs /usr/bin/gcov-${{ matrix.gcc_version }} /usr/bin/gcov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        gcc_version: ['10','11','12']
+        gcc_version: ['11','12','13','14']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y gcc-${{ matrix.gcc_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==3.3
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/0.32.0-772f5f4/ceedling-0.32.0-772f5f4.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/1.0.0-60c24c2/ceedling-1.0.0-60c24c2.gem -O ceedling.gem
         sudo gem install ceedling.gem
     - name: Unit tests
       run: make utest CC=gcc
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo apt-get install -y clang-${{ matrix.clang_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==3.3
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/0.32.0-772f5f4/ceedling-0.32.0-772f5f4.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/1.0.0-60c24c2/ceedling-1.0.0-60c24c2.gem -O ceedling.gem
         sudo gem install ceedling.gem
         sudo ln -fs /usr/bin/clang-${{ matrix.clang_version }} /usr/bin/clang
         sudo ln -fs /usr/bin/llvm-cov-${{ matrix.clang_version }} /usr/bin/llvm-cov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        gcc_version: ['11','12','13','14']
+        gcc_version: ['11','12','13']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ in library `inc/` folder and you need to point your compiler `-I` flag there.
 After you have your environment set you need to enter below flow to your program.
 
 ```C
-/* Before include, make sure you have BITS_PER_LONG defined. This is a CPU
- * specific value which is used to generate bit masks. You can also use -D
- * to input definition to compiler via command line
- */
 #include "mlx90632.h"
 
 /* Declare and implement here functions you find in mlx90632_depends.h */
@@ -90,10 +86,6 @@ in library `inc/` folder and you need to point your compiler `-I` flag there.
 After you have your environment set you need to enter below flow to your program.
 
 ```C
-/* Before include, make sure you have BITS_PER_LONG defined. This is a CPU
- * specific value which is used to generate bit masks. You can also use -D
- * to input definition to compiler via command line
- */
 #include "mlx90632.h"
 
 /* Declare and implement here functions you find in mlx90632_depends.h */
@@ -109,14 +101,14 @@ int main(void)
     double object; /**< Object temperature in degrees Celsius */
 
     /* Read sensor EEPROM registers needed for calcualtions */
-    
+
     /* You can check if the device supports extended measurement mode */
     ret = mlx90632_init();
     if(status == ERANGE)
     {
        /* Extended mode is supported */
     }
-    
+
     /* Set MLX90632 in extended mode */
     ret = mlx90632_set_meas_type(MLX90632_MTYP_EXTENDED)
     if(ret < 0)
@@ -131,15 +123,15 @@ int main(void)
 
     /* Now start calculations (no more i2c accesses) */
     /* Calculate ambient temperature */
-    ambient = mlx90632_calc_temp_ambient_extended(ambient_new_raw, ambient_old_raw, 
+    ambient = mlx90632_calc_temp_ambient_extended(ambient_new_raw, ambient_old_raw,
                                                   PT, PR, PG, PO, Gb);
-    
+
     /* Get preprocessed temperatures needed for object temperature calculation */
     double pre_ambient = mlx90632_preprocess_temp_ambient_extended(ambient_new_raw,
                                                                    ambient_old_raw, Gb);
     double pre_object = mlx90632_preprocess_temp_object_extended(object_new_raw, ambient_new_raw,
                                                                  ambient_old_raw, Ka);
-    
+
     /* Calculate object temperature assuming the reflected temperature equals ambient*/
     object = mlx90632_calc_temp_object_extended(pre_object, pre_ambient, ambient, Ea, Eb, Ga, Fa, Fb, Ha, Hb);
 }
@@ -152,10 +144,6 @@ in library `inc/` folder and you need to point your compiler `-I` flag there.
 After you have your environment set you need to enter below flow to your program.
 
 ```C
-/* Before include, make sure you have BITS_PER_LONG defined. This is a CPU
- * specific value which is used to generate bit masks. You can also use -D
- * to input definition to compiler via command line
- */
 #include "mlx90632.h"
 
 /* Declare and implement here functions you find in mlx90632_depends.h */
@@ -171,7 +159,7 @@ int main(void)
     double object; /**< Object temperature in degrees Celsius */
 
     /* Read sensor EEPROM registers needed for calcualtions */
-    
+
     /* Set MLX90632 in burst mode */
     ret = mlx90632_set_meas_type(MLX90632_MTYP_MEDICAL_BURST)
     if(ret < 0)
@@ -208,10 +196,6 @@ in library `inc/` folder and you need to point your compiler `-I` flag there.
 After you have your environment set you need to enter below flow to your program.
 
 ```C
-/* Before include, make sure you have BITS_PER_LONG defined. This is a CPU
- * specific value which is used to generate bit masks. You can also use -D
- * to input definition to compiler via command line
- */
 #include "mlx90632.h"
 
 /* Declare and implement here functions you find in mlx90632_depends.h */
@@ -227,14 +211,14 @@ int main(void)
     double object; /**< Object temperature in degrees Celsius */
 
     /* Read sensor EEPROM registers needed for calcualtions */
-    
+
     /* You can check if the device supports extended measurement mode */
     ret = mlx90632_init();
     if(status == ERANGE)
     {
        /* Extended mode is supported */
     }
-    
+
     /* Set MLX90632 in extended burst mode */
     ret = mlx90632_set_meas_type(MLX90632_MTYP_EXTENDED_BURST)
     if(ret < 0)
@@ -249,15 +233,15 @@ int main(void)
 
     /* Now start calculations (no more i2c accesses) */
     /* Calculate ambient temperature */
-    ambient = mlx90632_calc_temp_ambient_extended(ambient_new_raw, ambient_old_raw, 
+    ambient = mlx90632_calc_temp_ambient_extended(ambient_new_raw, ambient_old_raw,
                                                   PT, PR, PG, PO, Gb);
-    
+
     /* Get preprocessed temperatures needed for object temperature calculation */
     double pre_ambient = mlx90632_preprocess_temp_ambient_extended(ambient_new_raw,
                                                                    ambient_old_raw, Gb);
     double pre_object = mlx90632_preprocess_temp_object_extended(object_new_raw, ambient_new_raw,
                                                                  ambient_old_raw, Ka);
-    
+
     /* Calculate object temperature assuming the reflected temperature equals ambient*/
     object = mlx90632_calc_temp_object_extended(pre_object, pre_ambient, ambient, Ea, Eb, Ga, Fa, Fb, Ha, Hb);
 }
@@ -272,6 +256,6 @@ faster development with automatic mocking ([CMock](http://www.throwtheswitch.org
 and wider range of unit test macros ([Unity](http://www.throwtheswitch.org/unity/)).
 Because of it, cloning repository requires adding a `--recursive` flag
 (so `git clone --recursive <url> <destination>`) or initialization of submodules
-afterwards using `git submodule update --init --recursive`. 
+afterwards using `git submodule update --init --recursive`.
 
 

--- a/doxygen/main.dox
+++ b/doxygen/main.dox
@@ -35,10 +35,6 @@
  * After you have your environment set you need to enter below flow to your program.
  *
  * \code{.c}
- * /* Before include, make sure you have BITS_PER_LONG defined. This is a CPU
- *  * specific value which is used to generate bit masks. You can also use -D
- *  * to input definition to compiler via command line
- *  */
  * #include "mlx90632.h"
  *
  * /* Declare and implement here functions you find in mlx90632_depends.h */

--- a/inc/mlx90632.h
+++ b/inc/mlx90632.h
@@ -64,10 +64,6 @@
 #define BIT(x)(1U << (x))
 #endif
 #ifndef GENMASK
-#ifndef BITS_PER_LONG
-#warning "Using default BITS_PER_LONG value"
-#define BITS_PER_LONG 64 /**< Define how many bits per long your CPU has */
-#endif
 #define GENMASK(h, l) \
         ((((1U << h) - 1) | (1U << h)) & ~((1U << l) - 1))
 #endif


### PR DESCRIPTION
Last refactoring managed to remove dependency on BITS_PER_LONG macro as GENMASK was simplified. The BITS_PER_LONG was still used in documentation and check in header file forcing users to define a macro value which is then anyway not used.

Additionally some whitespace fixup was also performed.

Closes #52 