### PR TITLE
chore(GH-56): mlx90632_unlock_eeprom function name typo fix

### DIFF
--- a/inc/mlx90632.h
+++ b/inc/mlx90632.h
@@ -208,6 +208,8 @@ typedef enum mlx90632_meas_e {
 #define MLX90632_NEW_REG_VALUE(old_reg, new_value, h, l) \
         ((old_reg & (0xFFFF ^ GENMASK(h, l))) | (new_value << MLX90632_EE_REFRESH_RATE_SHIFT))
 
+#define mlx90632_unlock_eeporm mlx90632_unlock_eeprom __attribute__ ((deprecated("Renamed to mlx90632_unlock_eeprom")))
+
 /** Read raw ambient and object temperature only when measurement data is ready
  *
  * Read raw ambient and object temperatures without waiting. This values still need

--- a/src/mlx90632.c
+++ b/src/mlx90632.c
@@ -675,7 +675,7 @@ int32_t mlx90632_trigger_measurement_single(void)
     return ret;
 }
 
-STATIC int32_t mlx90632_unlock_eeporm(void)
+STATIC int32_t mlx90632_unlock_eeprom(void)
 {
     return mlx90632_i2c_write(0x3005, MLX90632_EEPROM_WRITE_KEY);
 }
@@ -695,7 +695,7 @@ STATIC int32_t mlx90632_wait_for_eeprom_not_busy(void)
 
 STATIC int32_t mlx90632_erase_eeprom(uint16_t address)
 {
-    int32_t ret = mlx90632_unlock_eeporm();
+    int32_t ret = mlx90632_unlock_eeprom();
 
     if (ret < 0)
         return ret;
@@ -715,7 +715,7 @@ STATIC int32_t mlx90632_write_eeprom(uint16_t address, uint16_t data)
     if (ret < 0)
         return ret;
 
-    ret = mlx90632_unlock_eeporm();
+    ret = mlx90632_unlock_eeprom();
     if (ret < 0)
         return ret;
 


### PR DESCRIPTION
Closes #56 