### PR TITLE
Drop some clang compiler support and update ceedling version

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        gcc_version: ['10','11','12']
+        gcc_version: ['10','11','12','13','14']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: ['11','12','13','14','15']
+        clang_version: ['14','15','16','17']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
         pip3 install mlx.warnings
     - name: Execute and build documentation
       run: |
-        mlx-warnings --doxygen --exact-warnings 3 --command make doxy
+        mlx-warnings --doxygen --exact-warnings 1 --command make doxy
     - name: Upload HTML documentation
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         mlx-warnings --doxygen --exact-warnings 3 --command make doxy
     - name: Upload HTML documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html-doc
         path: ./build/html/doxygen/html
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download HTML documentation from job 'test'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: html-doc
         path: ./build/html/doxygen/html
     - name: Disable jekyll
       run: touch ./build/html/doxygen/html/.nojekyll
     - name: Deploy documentation
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html/doxygen/html

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        gcc_version: ['11','12','13']
+        gcc_version: ['11','12','13','14']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y gcc-${{ matrix.gcc_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==8.2
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.0/ceedling-1.0.0.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.1/ceedling-1.0.1.gem -O ceedling.gem
         sudo gem install ceedling.gem
     - name: Unit tests
       run: make utest CC=gcc
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: ['11','12','13','14','15']
+        clang_version: ['14','15','16','17']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo apt-get install -y clang-${{ matrix.clang_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==8.2
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.0/ceedling-1.0.0.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.1/ceedling-1.0.1.gem -O ceedling.gem
         sudo gem install ceedling.gem
         sudo ln -fs /usr/bin/clang-${{ matrix.clang_version }} /usr/bin/clang
         sudo ln -fs /usr/bin/llvm-cov-${{ matrix.clang_version }} /usr/bin/llvm-cov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y gcc-${{ matrix.gcc_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==8.2
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.1/ceedling-1.0.1.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/1.0.1/ceedling-1.0.1.gem -O ceedling.gem
         sudo gem install ceedling.gem
     - name: Unit tests
       run: make utest CC=gcc
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo apt-get install -y clang-${{ matrix.clang_version }} ruby rake gcc-multilib lcov wget
         pip install --user gcovr==8.2
-        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/v1.0.1/ceedling-1.0.1.gem -O ceedling.gem
+        wget https://github.com/ThrowTheSwitch/Ceedling/releases/download/1.0.1/ceedling-1.0.1.gem -O ceedling.gem
         sudo gem install ceedling.gem
         sudo ln -fs /usr/bin/clang-${{ matrix.clang_version }} /usr/bin/clang
         sudo ln -fs /usr/bin/llvm-cov-${{ matrix.clang_version }} /usr/bin/llvm-cov

--- a/doxygen/doxyfile
+++ b/doxygen/doxyfile
@@ -230,12 +230,6 @@ TAB_SIZE               = 4
 
 ALIASES                = 
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              = 
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -1026,13 +1020,6 @@ CLANG_OPTIONS          =
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
-
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
 # can be used to specify a prefix (or a list of prefixes) that should be ignored
@@ -1159,15 +1146,6 @@ HTML_COLORSTYLE_SAT    = 100
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_COLORSTYLE_GAMMA  = 80
-
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = YES
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
@@ -1438,17 +1416,6 @@ EXT_LINKS_IN_WINDOW    = NO
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 FORMULA_FONTSIZE       = 10
-
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # http://www.mathjax.org) which uses client side Javascript for the rendering
@@ -1728,16 +1695,6 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
-
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
 # http://en.wikipedia.org/wiki/BibTeX and \cite for more info.
@@ -1801,16 +1758,6 @@ RTF_STYLESHEET_FILE    =
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
 RTF_EXTENSIONS_FILE    = 
-
-# If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
-# with syntax highlighting in the RTF output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_RTF is set to YES.
-
-RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -1900,15 +1847,6 @@ GENERATE_DOCBOOK       = NO
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
 DOCBOOK_OUTPUT         = docbook
-
-# If the DOCBOOK_PROGRAMLISTING tag is set to YES, doxygen will include the
-# program listings (including syntax highlighting and cross-referencing
-# information) to the DOCBOOK output. Note that enabling this will significantly
-# increase the size of the DOCBOOK output.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_DOCBOOK is set to YES.
-
-DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2088,15 +2026,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
@@ -2128,23 +2057,6 @@ HAVE_DOT               = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
-
-# When you want a differently looking font in the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2352,18 +2264,6 @@ DOT_GRAPH_MAX_NODES    = 200
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This


### PR DESCRIPTION
Clang versions up to 13 no longer have installation packages available, so we can drop their support from our tests. Meanwhile I also updated to patched Ceedling version, which should not have any regressions for us